### PR TITLE
Fixed notice thrown in bootstrap.php

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,7 +10,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Event\ConfigureLocales;
 
 return function (Dispatcher $events) {
-    $events->subscribe(Spanish);
+    $events->subscribe('Spanish');
 };
 
 class Spanish {


### PR DESCRIPTION
Hi there,

Flarum beta 4 throws a notice in bootstrap.php. I'm new to Flarum but I guess when you type in "Spanish" as a constant name you are referencing the "Spanish" class, which is a string. PHP assumes this and works, but still throws the notice with your current code.

Just typed in the quotation marks.

Regards.